### PR TITLE
Fix failed to run execsnoop

### DIFF
--- a/src/7-execsnoop/README.md
+++ b/src/7-execsnoop/README.md
@@ -52,7 +52,7 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
 {
  u64 id;
  pid_t pid, tgid;
- struct event event;
+ struct event event={0};
  struct task_struct *task;
 
  uid_t uid = (u32)bpf_get_current_uid_gid();

--- a/src/7-execsnoop/execsnoop.bpf.c
+++ b/src/7-execsnoop/execsnoop.bpf.c
@@ -15,7 +15,7 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
 {
 	u64 id;
 	pid_t pid, tgid;
-	struct event event;
+	struct event event={0};
 	struct task_struct *task;
 
 	uid_t uid = (u32)bpf_get_current_uid_gid();


### PR DESCRIPTION
without having initialised it, the verifier complains, because reading uninitialised memory from the kernel introduces a security risk.
![image](https://user-images.githubusercontent.com/50291063/234036538-d82af6e8-b780-45bb-9875-081c1b4918d0.png)
