### PR TITLE
 fix(execsnoop): get the correct process name

### DIFF
--- a/src/7-execsnoop/README.md
+++ b/src/7-execsnoop/README.md
@@ -63,7 +63,8 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
  event.uid = uid;
  task = (struct task_struct*)bpf_get_current_task();
  event.ppid = BPF_CORE_READ(task, real_parent, tgid);
- bpf_get_current_comm(&event.comm, sizeof(event.comm));
+ char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
+ bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
  bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
  return 0;
 }

--- a/src/7-execsnoop/README.md
+++ b/src/7-execsnoop/README.md
@@ -1,4 +1,4 @@
-# eBPF 入门实践教程七：捕获进程执行/退出时间，通过 perf event array 向用户态打印输出
+# eBPF 入门实践教程七：捕获进程执行事件，通过 perf event array 向用户态打印输出
 
 eBPF (Extended Berkeley Packet Filter) 是 Linux 内核上的一个强大的网络和性能分析工具，它允许开发者在内核运行时动态加载、更新和运行用户定义的代码。
 

--- a/src/7-execsnoop/README.md
+++ b/src/7-execsnoop/README.md
@@ -21,12 +21,12 @@ eBPF 提供了两个环形缓冲区，可以用来将信息从 eBPF 程序传输
 #define TASK_COMM_LEN 16
 
 struct event {
- int pid;
- int ppid;
- int uid;
- int retval;
- bool is_exit;
- char comm[TASK_COMM_LEN];
+    int pid;
+    int ppid;
+    int uid;
+    int retval;
+    bool is_exit;
+    char comm[TASK_COMM_LEN];
 };
 
 #endif /* __EXECSNOOP_H */
@@ -42,31 +42,31 @@ struct event {
 #include "execsnoop.h"
 
 struct {
- __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
- __uint(key_size, sizeof(u32));
- __uint(value_size, sizeof(u32));
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
 } events SEC(".maps");
 
 SEC("tracepoint/syscalls/sys_enter_execve")
 int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx)
 {
- u64 id;
- pid_t pid, tgid;
- struct event event={0};
- struct task_struct *task;
+    u64 id;
+    pid_t pid, tgid;
+    struct event event={0};
+    struct task_struct *task;
 
- uid_t uid = (u32)bpf_get_current_uid_gid();
- id = bpf_get_current_pid_tgid();
- tgid = id >> 32;
+    uid_t uid = (u32)bpf_get_current_uid_gid();
+    id = bpf_get_current_pid_tgid();
+    tgid = id >> 32;
 
- event.pid = tgid;
- event.uid = uid;
- task = (struct task_struct*)bpf_get_current_task();
- event.ppid = BPF_CORE_READ(task, real_parent, tgid);
- char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
- bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
- bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
- return 0;
+    event.pid = tgid;
+    event.uid = uid;
+    task = (struct task_struct*)bpf_get_current_task();
+    event.ppid = BPF_CORE_READ(task, real_parent, tgid);
+    char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
+    bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/7-execsnoop/README_en.md
+++ b/src/7-execsnoop/README_en.md
@@ -1,4 +1,4 @@
-# eBPF Beginner's Practical Tutorial Seven: Capturing Process Execution/Exit Time, Printing Output to User Space via perf event array
+# eBPF Beginner's Practical Tutorial Seven: Capturing Process Execution Event, Printing Output to User Space via perf event array
 
 eBPF (Extended Berkeley Packet Filter) is a powerful network and performance analysis tool on the Linux kernel that allows developers to dynamically load, update, and run user-defined code at runtime.
 

--- a/src/7-execsnoop/README_en.md
+++ b/src/7-execsnoop/README_en.md
@@ -63,7 +63,8 @@ int tracepoint_syscalls_sys_enter_execve(struct trace_event_raw_sys_enter* ctx)
  event.uid = uid;
  task = (struct task_struct*)bpf_get_current_task();
  event.ppid = BPF_CORE_READ(task, real_parent, tgid);
- bpf_get_current_comm(&event.comm, sizeof(event.comm));
+ char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
+ bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
  bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
  return 0;
 }
@@ -73,7 +74,7 @@ char LICENSE[] SEC("license") = "GPL";
 
 This code defines an eBPF program for capturing the entry of the `execve` system call.
 
-In the entry program, we first obtain the process ID and user ID of the current process, then use the `bpf_get_current_task` function to obtain the `task_struct` structure of the current process, and use the `bpf_get_current_comm` function to read the process name. Finally, we use the `bpf_perf_event_output` function to output the process execution event to the perf buffer.
+In the entry program, we first obtain the process ID and user ID of the current process, then use the `bpf_get_current_task` function to obtain the `task_struct` structure of the current process, and use the `bpf_probe_read_str` function to read the process name. Finally, we use the `bpf_perf_event_output` function to output the process execution event to the perf buffer.
 
 With this code, we can capture process execution events in the Linux kernel and analyze the process execution conditions.Instructions: Translate the following Chinese text to English while maintaining the original formatting:
 

--- a/src/7-execsnoop/README_en.md
+++ b/src/7-execsnoop/README_en.md
@@ -21,12 +21,12 @@ Header file: execsnoop.h
 #define TASK_COMM_LEN 16
 
 struct event {
- int pid;
- int ppid;
- int uid;
- int retval;
- bool is_exit;
- char comm[TASK_COMM_LEN];
+    int pid;
+    int ppid;
+    int uid;
+    int retval;
+    bool is_exit;
+    char comm[TASK_COMM_LEN];
 };
 
 #endif /* __EXECSNOOP_H */
@@ -42,31 +42,31 @@ Source file: execsnoop.bpf.c
 #include "execsnoop.h"
 
 struct {
- __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
- __uint(key_size, sizeof(u32));
- __uint(value_size, sizeof(u32));
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
 } events SEC(".maps");
 
 SEC("tracepoint/syscalls/sys_enter_execve")
 int tracepoint_syscalls_sys_enter_execve(struct trace_event_raw_sys_enter* ctx)
 {
- u64 id;
- pid_t pid, tgid;
- struct event event={0};
- struct task_struct *task;
+    u64 id;
+    pid_t pid, tgid;
+    struct event event={0};
+    struct task_struct *task;
 
- uid_t uid = (u32)bpf_get_current_uid_gid();
- id = bpf_get_current_pid_tgid();
- tgid = id >> 32;
+    uid_t uid = (u32)bpf_get_current_uid_gid();
+    id = bpf_get_current_pid_tgid();
+    tgid = id >> 32;
 
- event.pid = tgid;
- event.uid = uid;
- task = (struct task_struct*)bpf_get_current_task();
- event.ppid = BPF_CORE_READ(task, real_parent, tgid);
- char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
- bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
- bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
- return 0;
+    event.pid = tgid;
+    event.uid = uid;
+    task = (struct task_struct*)bpf_get_current_task();
+    event.ppid = BPF_CORE_READ(task, real_parent, tgid);
+    char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
+    bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
+    return 0;
 }
 
 char LICENSE[] SEC("license") = "GPL";

--- a/src/7-execsnoop/execsnoop.bpf.c
+++ b/src/7-execsnoop/execsnoop.bpf.c
@@ -26,7 +26,8 @@ int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter* ctx
 	event.uid = uid;
 	task = (struct task_struct*)bpf_get_current_task();
 	event.ppid = BPF_CORE_READ(task, real_parent, tgid);
-	bpf_get_current_comm(&event.comm, sizeof(event.comm));
+	char *cmd_ptr = (char *) BPF_CORE_READ(ctx, args[0]);
+	bpf_probe_read_str(&event.comm, sizeof(event.comm), cmd_ptr);
 	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(event));
 	return 0;
 }


### PR DESCRIPTION
# Pull Request Template

## Description

1. The process name should be the subprocess name, not the parent process name that call `exec`
2. Fix the title. The program doesn't cache the exit event.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
