### PR TITLE
libssl's path should not be hard coded

### DIFF
--- a/src/30-sslsniff/README.md
+++ b/src/30-sslsniff/README.md
@@ -315,7 +315,7 @@ int BPF_URETPROBE(probe_SSL_do_handshake_exit) {
     if (env.openssl) {
         char *openssl_path = find_library_path("libssl.so");
         printf("OpenSSL path: %s\n", openssl_path);
-        attach_openssl(obj, "/lib/x86_64-linux-gnu/libssl.so.3");
+        attach_openssl(obj, openssl_path);
     }
     if (env.gnutls) {
         char *gnutls_path = find_library_path("libgnutls.so");
@@ -343,7 +343,7 @@ int BPF_URETPROBE(probe_SSL_do_handshake_exit) {
       skel->links.prog_name = bpf_program__attach_uprobe_opts(                 \
           skel->progs.prog_name, env.pid, binary_path, 0, &uprobe_opts);       \
     } while (false)
-    
+
 int attach_openssl(struct sslsniff_bpf *skel, const char *lib) {
     ATTACH_UPROBE_CHECKED(skel, lib, SSL_write, probe_SSL_rw_enter);
     ATTACH_URETPROBE_CHECKED(skel, lib, SSL_write, probe_SSL_write_exit);
@@ -411,9 +411,9 @@ void print_event(struct probe_SSL_data_t *event, const char *evt) {
     if (buf_size != 0) {
         if (env.hexdump) {
             // 2 characters for each byte + null terminator
-            char hex_data[MAX_BUF_SIZE * 2 + 1] = {0};  
+            char hex_data[MAX_BUF_SIZE * 2 + 1] = {0};
             buf_to_hex((uint8_t *)buf, buf_size, hex_data);
-            
+
             printf("\n%s\n", s_mark);
             for (size_t i = 0; i < strlen(hex_data); i += 32) {
                 printf("%.32s\n", hex_data + i);
@@ -477,7 +477,7 @@ curl https://example.com
 当执行 `curl` 命令后，`sslsniff` 会显示以下内容：
 
 ```txt
-    READ/RECV    0.132786160        curl             47458   1256  
+    READ/RECV    0.132786160        curl             47458   1256
     ----- DATA -----
     <!doctype html>
     ...
@@ -503,7 +503,7 @@ OpenSSL path: /lib/x86_64-linux-gnu/libssl.so.3
 GnuTLS path: /lib/x86_64-linux-gnu/libgnutls.so.30
 NSS path: /lib/x86_64-linux-gnu/libnspr4.so
 FUNC         TIME(s)            COMM             PID     LEN     LAT(ms)
-HANDSHAKE    0.000000000        curl             6460    1      1.384  WRITE/SEND   0.000115400        curl             6460    24     0.014 
+HANDSHAKE    0.000000000        curl             6460    1      1.384  WRITE/SEND   0.000115400        curl             6460    24     0.014
 ```
 
 ### 16进制输出
@@ -512,7 +512,7 @@ HANDSHAKE    0.000000000        curl             6460    1      1.384  WRITE/SEN
 
 ```console
 $ sudo ./sslsniff --hexdump
-WRITE/SEND   0.000000000        curl             16104   24    
+WRITE/SEND   0.000000000        curl             16104   24
 ----- DATA -----
 505249202a20485454502f322e300d0a
 0d0a534d0d0a0d0a

--- a/src/30-sslsniff/README_en.md
+++ b/src/30-sslsniff/README_en.md
@@ -325,7 +325,7 @@ To achieve this functionality, the `find_library_path` function is first used to
     if (env.openssl) {
         char *openssl_path = find_library_path("libssl.so");
         printf("OpenSSL path: %s\n", openssl_path);
-        attach_openssl(obj, "/lib/x86_64-linux-gnu/libssl.so.3");
+        attach_openssl(obj, openssl_path);
     }
     if (env.gnutls) {
         char *gnutls_path = find_library_path("libgnutls.so");
@@ -353,7 +353,7 @@ The specific `attach` functions are as follows:
       skel->links.prog_name = bpf_program__attach_uprobe_opts(                 \
           skel->progs.prog_name, env.pid, binary_path, 0, &uprobe_opts);       \
     } while (false)
-    
+
 int attach_openssl(struct sslsniff_bpf *skel, const char *lib) {
     ATTACH_UPROBE_CHECKED(skel, lib, SSL_write, probe_SSL_rw_enter);
     ATTACH_URETPROBE_CHECKED(skel, lib, SSL_write, probe_SSL_write_exit);
@@ -421,9 +421,9 @@ void print_event(struct probe_SSL_data_t *event, const char *evt) {
     if (buf_size != 0) {
         if (env.hexdump) {
             // 2 characters for each byte + null terminator
-            char hex_data[MAX_BUF_SIZE * 2 + 1] = {0};  
+            char hex_data[MAX_BUF_SIZE * 2 + 1] = {0};
             buf_to_hex((uint8_t *)buf, buf_size, hex_data);
-            
+
             printf("\n%s\n", s_mark);
             for (size_t i = 0; i < strlen(hex_data); i += 32) {
                 printf("%.32s\n", hex_data + i);
@@ -485,7 +485,7 @@ Under normal circumstances, you will see output similar to the following:
 After executing the `curl` command, `sslsniff` will display the following content:
 
 ```txt
-    READ/RECV    0.132786160        curl             47458   1256  
+    READ/RECV    0.132786160        curl             47458   1256
     ----- DATA -----
     <!doctype html>
     ...
@@ -511,7 +511,7 @@ OpenSSL path: /lib/x86_64-linux-gnu/libssl.so.3
 GnuTLS path: /lib/x86_64-linux-gnu/libgnutls.so.30
 NSS path: /lib/x86_64-linux-gnu/libnspr4.so
 FUNC         TIME(s)            COMM             PID     LEN     LAT(ms)
-HANDSHAKE    0.000000000        curl             6460    1      1.384  WRITE/SEND   0.000115400        curl             6460    24     0.014 
+HANDSHAKE    0.000000000        curl             6460    1      1.384  WRITE/SEND   0.000115400        curl             6460    24     0.014
 ```
 
 ### Hexadecimal Output
@@ -520,7 +520,7 @@ To display data in hexadecimal format, execute the following command:
 
 ```console
 $ sudo ./sslsniff --hexdump
-WRITE/SEND   0.000000000        curl             16104   24    
+WRITE/SEND   0.000000000        curl             16104   24
 ----- DATA -----
 505249202a20485454502f322e300d0a
 0d0a534d0d0a0d0a

--- a/src/30-sslsniff/sslsniff.c
+++ b/src/30-sslsniff/sslsniff.c
@@ -397,7 +397,7 @@ int main(int argc, char **argv) {
 	if (env.openssl) {
 		char *openssl_path = find_library_path("libssl.so");
 		printf("OpenSSL path: %s\n", openssl_path);
-		attach_openssl(obj, "/lib/x86_64-linux-gnu/libssl.so.3");
+		attach_openssl(obj, openssl_path);
 	}
 	if (env.gnutls) {
 		char *gnutls_path = find_library_path("libgnutls.so");


### PR DESCRIPTION
## Description

libssl's path should not be hard coded.
For example, on my Rocky Linux 9, the library is `/lib64/libssl.so.3`.

Running 30-sslsniff failed because of wrong libssl.so path `/lib/x86_64-linux-gnu/libssl.so.3`:

```bash
$ ./sslsniff 
OpenSSL path: /lib64/libssl.so.3
libbpf: elf: failed to open /lib/x86_64-linux-gnu/libssl.so.3: No such file or directory
no program attached for probe_SSL_rw_enter: No such file or directory
GnuTLS path: /lib64/libgnutls.so.30
NSS path: /lib64/libnspr4.so
FUNC         TIME(s)            COMM             PID     LEN    
```
