### PR TITLE
Fix the compilation error of 24-hide

### DIFF
--- a/src/24-hide/pidhide.bpf.c
+++ b/src/24-hide/pidhide.bpf.c
@@ -58,7 +58,7 @@ const volatile int target_ppid = 0;
 // of the PID to hide. This becomes the name
 // of the folder in /proc/
 const volatile int pid_to_hide_len = 0;
-const volatile char pid_to_hide[MAX_PID_LEN];
+const volatile char pid_to_hide[MAX_PID_LEN] = "";
 
 // struct linux_dirent64 {
 //     u64        d_ino;    /* 64-bit inode number */


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes # (issue)

Fix 'libbpf: failed to find BTF info for global/extern symbol' since uninitialized global variables

https://github.com/eunomia-bpf/bpf-developer-tutorial/issues/143

## Type of change

<!--Please delete options that are not relevant.-->

- [ ✓ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] Test A
- [ ] Test B

**Test Configuration**:


* Ubuntu 20.04
* Linux version 5.15.0-124-generic 
* clang version 10.0.0-4ubuntu1 



## Checklist

- [ ✓ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ✓] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
