### PR TITLE
42-xdp-loadbalancer: fix various bugs which prevented the example from working

### DIFF
--- a/src/42-xdp-loadbalancer/README.md
+++ b/src/42-xdp-loadbalancer/README.md
@@ -445,8 +445,11 @@ sudo ./teardown.sh
 ### Running the Load Balancer
 
 To run the XDP load balancer, execute the following command, specifying the interface and backends' IP and MAC addresses:
+To make XDP work with veth interfaces we need to add a stub eBPF program to the other end of the pair.
 
 ```console
+clang -target bpf -o stub.bpf.o -c stub.bpf.c
+sudo ip l set dev veth7 xdp obj ./stub.bpf.o sec .xdp # stub XDP_PASS on the receiving interface
 sudo ip netns exec lb ./xdp_lb veth6 10.0.0.2 de:ad:be:ef:00:02 10.0.0.3 de:ad:be:ef:00:03
 ```
 

--- a/src/42-xdp-loadbalancer/stub.bpf.c
+++ b/src/42-xdp-loadbalancer/stub.bpf.c
@@ -1,0 +1,8 @@
+#include <bpf/bpf.h>
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+SEC(".xdp")
+
+int main () {
+  return XDP_PASS;
+}

--- a/src/42-xdp-loadbalancer/xdp_lb.bpf.c
+++ b/src/42-xdp-loadbalancer/xdp_lb.bpf.c
@@ -8,6 +8,8 @@
 #include <linux/tcp.h>
 #include "xx_hash.h"
 
+#define MAX_TCP_CHECK_WORDS 750 // max 1500 bytes to check in TCP checksum. This is MTU dependent
+
 struct backend_config {
     __u32 ip;
     unsigned char mac[ETH_ALEN];
@@ -36,6 +38,35 @@ csum_fold_helper(__u64 csum)
             csum = (csum & 0xffff) + (csum >> 16);
     }
     return ~csum;
+}
+
+static __always_inline __u16
+tcph_csum(struct tcphdr *tcph, struct iphdr *iph, void *data_end)
+{
+    // Clear checksum
+    tcph->check = 0;
+
+    // Pseudo header checksum calculation
+    __u32 sum = 0;
+    sum += (__u16)(iph->saddr >> 16) + (__u16)(iph->saddr & 0xFFFF);
+    sum += (__u16)(iph->daddr >> 16) + (__u16)(iph->daddr & 0xFFFF);
+    sum += __constant_htons(IPPROTO_TCP);
+    sum += __constant_htons((__u16)(data_end - (void *)tcph));
+
+    // TCP header and payload checksum
+    #pragma clang loop unroll_count(MAX_TCP_CHECK_WORDS)
+    for (int i = 0;i <=MAX_TCP_CHECK_WORDS ; i++) {
+    void *ptr = (__u16 *)tcph + i;
+    if ((void *)ptr + 2 > data_end)
+        break;
+    sum += *(__u16 *)ptr;
+    }
+
+    // fold into 16 bit
+    while (sum >> 16)
+        sum = (sum & 0xFFFF) + (sum >> 16);
+
+    return ~sum;
 }
 
 static __always_inline __u16
@@ -102,7 +133,10 @@ int xdp_load_balancer(struct xdp_md *ctx) {
     __builtin_memcpy(eth->h_source, load_balancer_mac, ETH_ALEN);
 
     // Recalculate IP checksum
-	iph->check = iph_csum(iph);
+    iph->check = iph_csum(iph);
+
+    // Recalculate TCP checksum
+    tcph->check = tcph_csum(tcph, iph, data_end);
 
     bpf_printk("Redirecting packet to new IP 0x%x from IP 0x%x", 
                 bpf_ntohl(iph->daddr), 


### PR DESCRIPTION
## Description

When I started testing this example it did not work for me at all. Eventually I found 3 bugs which prevented this from working correctly:

1. veth silently swallows packets after `XDP_TX`. The receiving end of the `veth` pair needs a stub XDP program for allocating the necessary resources see netdev mailinglist [here](https://www.spinics.net/lists/netdev/msg625217.html) and [here](https://www.spinics.net/lists/netdev/msg625862.html)
2. The TCP checksum mismatched and packets got dropped
3. Each packet was balanced individually, breaking TCP flows, resulting in only a third of the requests succeeding. 

Let me know if this is of interest for this repository, I'm happy to refactor if necessary.

## Fixes
#160

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

After the changes applied, one can follow the commands in the README.md and everything works as expected.

**Test Configuration**:

```
Linux gate01 6.15.6-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 10 Jul 2025 17:10:18 +0000 x86_64 GNU/Linux
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
