### PR TITLE
fix(tp/syscalls): detach handle_getdents_patch on sys_exit_getdents64

### DIFF
--- a/src/24-hide/pidhide.bpf.c
+++ b/src/24-hide/pidhide.bpf.c
@@ -174,7 +174,7 @@ int handle_getdents_exit(struct trace_event_raw_sys_exit *ctx)
     return 0;
 }
 
-SEC("tp/syscalls/sys_exit_getdents64")
+SEC("tp/unused")
 int handle_getdents_patch(struct trace_event_raw_sys_exit *ctx)
 {
     // Only patch if we've already checked and found our pid's folder to hide

--- a/src/24-hide/pidhide.c
+++ b/src/24-hide/pidhide.c
@@ -180,6 +180,9 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
+	// 禁用 patch 程序的自动 attach，因为它只能通过尾调用执行
+    bpf_program__set_autoattach(skel->progs.handle_getdents_patch, false);
+
     // Setup Maps for tail calls
     int index = PROG_01;
     int prog_fd = bpf_program__fd(skel->progs.handle_getdents_exit);


### PR DESCRIPTION
确保 handle_getdents_patch 仅通过尾调用执行。
移除在 sys_exit_getdents64 上的 attach，避免非尾调用路径被意外触发。

<!--# Pull Request Template-->

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

handle_getdents_patch  挂载到 sys_exit_getdents64 导致意外触发：

开启 bpf 程序
```bash
$ sudo ./pidhide -p 123200
```

 tracepide 日志显示，非目标 PID 的目录项命中：filename next one  空串

```bash
root@ubuntu:~# cat /sys/kernel/debug/tracing/trace_pipe 
              ps-123338  [000] ...21 10421.364238: bpf_trace_printk: [PID_HIDE] filename previous 123199

              ps-123338  [000] ...21 10421.364375: bpf_trace_printk: [PID_HIDE] filename next one 123200

              ps-123340  [000] ...21 10422.805415: bpf_trace_printk: [PID_HIDE] filename previous 123199

              ps-123340  [000] ...21 10422.805417: bpf_trace_printk: [PID_HIDE] filename next one 123200

  systemd-sysctl-134681  [002] .N.21 12563.646532: bpf_trace_printk: [PID_HIDE] filename previous 10-c

  systemd-sysctl-134681  [002] .N.21 12563.647119: bpf_trace_printk: [PID_HIDE] filename next one 

  systemd-sysctl-134681  [000] ...21 12563.647936: bpf_trace_printk: [PID_HIDE] filename previous 99-p

  systemd-sysctl-134681  [000] ...21 12563.647981: bpf_trace_printk: [PID_HIDE] filename next one
```

Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

不再出现非目标 PID 命中：

```bash
root@ubuntu:~# cat /sys/kernel/debug/tracing/trace_pipe 




              ps-139927  [003] ...21 13739.866242: bpf_trace_printk: [PID_HIDE] filename previous 123199

              ps-139927  [003] ...21 13739.866575: bpf_trace_printk: [PID_HIDE] filename next one 123200

           <...>-139928  [002] ...21 13748.956035: bpf_trace_printk: [PID_HIDE] filename previous 123199

           <...>-139928  [002] ...21 13748.956543: bpf_trace_printk: [PID_HIDE] filename next one 123200
```
**Test Configuration**:

```bash
Linux ubuntu 6.8.0-60-generic #63~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue Apr 22 19:00:15 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
