### PR TITLE
fix(32-wallclock-profiler): use absolute path to find tool paths

### DIFF
--- a/src/32-wallclock-profiler/wallclock_profiler.py
+++ b/src/32-wallclock-profiler/wallclock_profiler.py
@@ -32,7 +32,7 @@ class CombinedProfiler:
         self.offcpu_error = None
         
         # Find tool paths
-        self.script_dir = Path(__file__).parent
+        self.script_dir = Path(__file__).absolute().parent
         self.oncpu_tool = self.script_dir / "oncputime"
         self.offcpu_tool = self.script_dir / "offcputime"
         


### PR DESCRIPTION
Problem:

`Path(__file__)` can be ".", in such case `self.oncpu_tool` is "oncputime", which can not be found by the shell.

Solution:

Translate `Path(__file__)` to absolute path.


**Please try to use the copilot to summary your PR. You don't need to fill all info below, just it can help giving your a checklist.**

<!--# Pull Request Template-->

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
